### PR TITLE
chore(PLATFORM-11045): Silence PHP 8.3 warning in the old gwbbcode library

### DIFF
--- a/gwbbcode/gwbbcode.inc.php
+++ b/gwbbcode/gwbbcode.inc.php
@@ -535,7 +535,7 @@ function build_replace( $reg ) {
 
 		// Primary attributes
 		if ( $prof_attr_list[$attr] == $primary ) {
-			$bonus_level = array_sum( explode( '+', $bonus ) );
+			$bonus_level = @array_sum( explode( '+', $bonus ) );
 			// Invalid attribute level bonus
 			if ( $bonus_level > 4 || $bonus_level < 0 || ( $bonus_level == 4 && !$available_helmet ) ) {
 				$invalid_template = "Invalid attribute level bonus";


### PR DESCRIPTION
PHP 8.3 started emitting the following warnings for array_sum: "Addition is not supported on type string". See https://www.php.net/manual/en/function.array-sum.php.

Example stack trace:
```
PHP Warning: array_sum(): Addition is not supported on type string in /extensions/PvXCode/gwbbcode/gwbbcode.inc.php on line 538
	#0 [internal function]: MWExceptionHandler::handleError(int, string, string, int)
	#1 /extensions/PvXCode/gwbbcode/gwbbcode.inc.php(538): array_sum(array)
	#2 [internal function]: build_replace(array)
	#3 /extensions/PvXCode/gwbbcode/gwbbcode.inc.php(81): preg_replace_callback(string, string, string)
	#4 /extensions/PvXCode/classes/PvXCode.php(37): parseGwbbcode(string, string)
```

This extension is used only on one wiki (gwpvx.fandom.com) which isn't growing and during MW migration we had a note saying that we shouldn't invest time in this code. The original extension hasn't been maintained for 5 years, and the gwbbcode library dates back to 2007.

IMO best we can do is to silence the warning. During the next PHP major release this code might trigger an error, but until that time the wiki could be abandoned, so no more concern :)